### PR TITLE
Basic Tile Placement

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() {
         )
         .type_attribute(".types.InvalidRequest", "#[derive(Serialize, Deserialize)]")
         .type_attribute(".types.Move", "#[derive(Serialize, Deserialize)]")
+        .type_attribute(".types.PlaceTile", "#[derive(Serialize, Deserialize)]")
         .type_attribute(".types.GameState", "#[derive(Serialize, Deserialize)]")
         .type_attribute(".types.GameStatus", "#[derive(Serialize, Deserialize)]")
         .type_attribute(".types.Player", "#[derive(Serialize, Deserialize)]")

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,11 +1,13 @@
 use anyhow::{anyhow, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::iter::FromIterator;
 
+use crate::load_map;
 use crate::manager::{GameHandle, GameOptions};
 use crate::types::main_message::Body;
 use crate::types::{
     GameState, GameStatus, Heister, HeisterColor, Internal, MainMessage, MapPosition, Move,
-    MoveDirection, Player, Square, WallType,
+    MoveDirection, PlaceTile, Player, Square, Tile, WallType, DOOR_TYPES,
 };
 
 use log::{info, trace};
@@ -13,7 +15,8 @@ use log::{info, trace};
 #[derive(Debug)]
 pub struct Game {
     pub game_handle: GameHandle,
-    game_state: GameState,
+    pub game_state: GameState,
+    pub tile_deck: HashMap<String, Tile>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -25,9 +28,30 @@ pub enum MoveValidity {
 impl Game {
     pub fn new(game_handle: GameHandle, _game_options: GameOptions) -> Game {
         let game_state = GameState::new(game_handle.clone());
+        // TODO: implement proper decks & base them off of GameOptions
+        let tile_deck = load_map::load_tiles_from_json();
         Game {
             game_handle,
             game_state,
+            tile_deck,
+        }
+    }
+
+    fn draw_tile(&mut self) -> Option<&Tile> {
+        // TODO: shuffle tiles
+        match self.game_state.remaining_tiles {
+            0 => None,
+            _wildcard => {
+                let used_tile_names: HashSet<String> =
+                    HashSet::from_iter(self.game_state.tiles.iter().map(|t| t.name.clone()));
+                let all_tile_names = self.tile_deck.keys();
+                let unused_tile_names =
+                    Vec::from_iter(all_tile_names.filter(|t| !used_tile_names.contains(t.clone())));
+                let drawn_tile_name = unused_tile_names.first();
+
+                self.game_state.remaining_tiles -= 1;
+                self.tile_deck.get(drawn_tile_name.unwrap().clone())
+            }
         }
     }
 
@@ -130,21 +154,6 @@ impl Game {
         return None;
     }
 
-    fn door_matches_heister(wall: WallType, color: &HeisterColor) -> MoveValidity {
-        // Assumption: wall is one of the color-door types
-        // Treating MoveValidity like a bool here, since it's the result type
-        // I want anyways
-        if (wall == WallType::PurpleDoor && color == &HeisterColor::Purple)
-            || (wall == WallType::OrangeDoor && color == &HeisterColor::Orange)
-            || (wall == WallType::YellowDoor && color == &HeisterColor::Yellow)
-            || (wall == WallType::GreenDoor && color == &HeisterColor::Green)
-        {
-            return MoveValidity::Valid;
-        } else {
-            MoveValidity::Invalid("Can't move heister through wrong-colored door".to_string())
-        }
-    }
-
     fn move_blocked_by_wall(
         &self,
         heister_pos: &MapPosition,
@@ -194,6 +203,150 @@ impl Game {
         return MoveValidity::Valid;
     }
 
+    fn get_door_wall(square: &Square) -> Option<WallType> {
+        // Return the square's (exit) door, if it has one
+        let walls = square.get_walls();
+        let door = walls
+            .values()
+            .find(|&wt| DOOR_TYPES.iter().any(|&dt| wt == dt));
+        match door {
+            Some(d) => {
+                let ret = d.clone();
+                Some(ret.clone())
+            }
+            None => None,
+        }
+    }
+
+    fn get_door_direction(square: &Square) -> Option<MoveDirection> {
+        // Return the direction of the square's (exit) door, if it has one
+        match Self::get_door_wall(square) {
+            Some(_) => (),
+            None => return None,
+        };
+        for (dir, wall) in square.get_walls().iter() {
+            if DOOR_TYPES.contains(&wall) {
+                return Some(dir.clone());
+            }
+        }
+        None
+    }
+
+    fn move_in_direction(position: MapPosition, direction: &MoveDirection) -> MapPosition {
+        // Given a position and direction, return the position if you were to
+        // "Move" in that direction (one square)
+        match direction {
+            MoveDirection::North => MapPosition {
+                x: position.x,
+                y: position.y - 1,
+            },
+            MoveDirection::East => MapPosition {
+                x: position.x + 1,
+                y: position.y,
+            },
+            MoveDirection::South => MapPosition {
+                x: position.x,
+                y: position.y + 1,
+            },
+            MoveDirection::West => MapPosition {
+                x: position.x - 1,
+                y: position.y,
+            },
+        }
+    }
+
+    fn heister_tile_placement_positions(
+        &self,
+        grid: &HashMap<MapPosition, Square>,
+    ) -> Vec<MapPosition> {
+        // Return the places from which you could draw a tile
+        // AKA - squares where a matching heister is on a square with a HeisterColor door
+        let mut placement_locations: Vec<MapPosition> = Vec::new();
+        for heister in &self.game_state.heisters {
+            let color = heister.heister_color;
+            let square = grid
+                .get(&heister.map_position)
+                .expect("Heister on invalid square");
+            let maybe_door = Self::get_door_wall(square);
+            let door = match maybe_door {
+                Some(d) => d,
+                None => continue,
+            };
+            // TODO: put this in a helper?
+            match door {
+                WallType::PurpleDoor => {
+                    if color == HeisterColor::Purple {
+                        placement_locations.push(heister.map_position.clone());
+                    }
+                }
+                WallType::OrangeDoor => {
+                    if color == HeisterColor::Orange {
+                        placement_locations.push(heister.map_position.clone());
+                    }
+                }
+                WallType::GreenDoor => {
+                    if color == HeisterColor::Green {
+                        placement_locations.push(heister.map_position.clone());
+                    }
+                }
+                WallType::YellowDoor => {
+                    if color == HeisterColor::Purple {
+                        placement_locations.push(heister.map_position.clone());
+                    }
+                }
+                _wildcard => (),
+            }
+        }
+        placement_locations
+    }
+
+    fn heister_to_tile_entrance_positions(
+        &self,
+        grid: &HashMap<MapPosition, Square>,
+    ) -> HashMap<MapPosition, MapPosition> {
+        // Returns a map from current heister positions to their prospective tile_entrance
+        // positions, one tile away (if there are any such locations)
+        let heister_door_positions = self.heister_tile_placement_positions(&grid);
+        let mut tile_entrance_positions: HashMap<MapPosition, MapPosition> = HashMap::new();
+        for heister_pos in heister_door_positions {
+            let square = grid
+                .get(&heister_pos)
+                .expect("Heister must be on a valid square");
+            let dir = &Self::get_door_direction(square)
+                .expect("Square must have a door on it to be entered through");
+            tile_entrance_positions.insert(
+                heister_pos.clone(),
+                Self::move_in_direction(heister_pos, dir),
+            );
+        }
+        tile_entrance_positions
+    }
+
+    fn new_tile_position(position: &MapPosition, dir: &MoveDirection) -> MapPosition {
+        // From a tile entrance and move direction of the tile's orientation,
+        // return the MapPosition for that new tile to place it in the absolute grid
+        // This is doable since every tile has an entry square in some rotation of
+        // (1, 3) - except for starting tiles
+        match dir {
+            MoveDirection::North => MapPosition {
+                x: position.x - 1,
+                y: position.y - 3,
+            },
+            MoveDirection::East => MapPosition {
+                x: position.x,
+                y: position.y - 1,
+            },
+            MoveDirection::South => MapPosition {
+                x: position.x - 2,
+                y: position.y,
+            },
+            MoveDirection::West => MapPosition {
+                x: position.x - 3,
+                y: position.y - 2,
+            },
+        }
+    }
+
     fn process_move(&mut self, m: Move) -> MoveValidity {
         let heister_color = m.heister_color;
         let heister = self.get_heister_from_vec(heister_color).unwrap();
@@ -233,17 +386,66 @@ impl Game {
         }
     }
 
+    fn place_tile(&mut self, position: &MapPosition, direction: &MoveDirection) -> MoveValidity {
+        let tile = self.draw_tile();
+        match tile {
+            // TODO: figure out how to handle mismatched door case for {Color}Door
+            // into TileEntrance (mismatched/asymmetric walls on tile bounds)
+            Some(t) => {
+                let new_pos = Self::new_tile_position(position, direction);
+                let num_rotations = match direction {
+                    MoveDirection::North => 1,
+                    MoveDirection::East => 2,
+                    MoveDirection::South => 3,
+                    MoveDirection::West => 4,
+                };
+                let mut m: Vec<Vec<Square>> = t.to_matrix();
+                for _ in 0..num_rotations {
+                    m = Tile::rotate_matrix_clockwise(&m);
+                }
+
+                let rotated_tile = &Tile::from_matrix(m, t.name.clone(), new_pos);
+                self.game_state.tiles.push(rotated_tile.clone());
+
+                info!(
+                    "Added Tile {} at {:?} to Game map",
+                    rotated_tile.name, rotated_tile.position
+                );
+                MoveValidity::Valid
+            }
+            None => MoveValidity::Invalid("Couldn't draw tile from deck".to_string()),
+        }
+    }
+
+    fn process_tile_placement(&mut self, pt: PlaceTile) -> MoveValidity {
+        let grid = self.get_absolute_grid();
+        let heister_to_tile_entrance_locs = self.heister_to_tile_entrance_positions(&grid);
+        let heister_pos = heister_to_tile_entrance_locs
+            .iter()
+            .find(|&(_, te)| te == &pt.tile_entrance)
+            .expect("When placing a tile, the heister must be at a tile-reveal door")
+            .0;
+
+        let heister_square = grid
+            .get(heister_pos)
+            .expect("Heister must be on valid square");
+        let dir = &Self::get_door_direction(heister_square).unwrap();
+
+        self.place_tile(&pt.tile_entrance, dir)
+    }
+
     pub fn handle_message(&mut self, message: MainMessage) -> MoveValidity {
         // If we receive GameState or InvalidRequest at this endpoint, panic, it should never happen.
         info!("Received message: {:?}", message);
         let body = message.body.unwrap();
         let validity = match body {
             Body::Move(m) => self.process_move(Move::from_proto(m)),
+            Body::PlaceTile(pt) => self.process_tile_placement(PlaceTile::from_proto(pt)),
             Body::GameState(_gs) => {
-                MoveValidity::Invalid("GameState is invalid from players".to_string())
+                MoveValidity::Invalid("GameState Message is invalid from players".to_string())
             }
             Body::InvalidRequest(_ir) => {
-                MoveValidity::Invalid("InvalidRequest is invalid from players".to_string())
+                MoveValidity::Invalid("InvalidRequest Message is invalid from players".to_string())
             }
         };
         validity
@@ -424,5 +626,56 @@ pub mod tests {
             }
         }
         info!("All walls line up");
+    }
+
+    #[test]
+    pub fn test_tile_draw() -> () {
+        // We test with initial game state (1a), move Orange one square north,
+        // and then send a drawTile message.
+        let _ = env_logger::builder().is_test(true).try_init();
+        let game_handle = GameHandle("test_grid_walls_align".to_string());
+        let game_options = GameOptions::default();
+        let mut game = super::Game::new(game_handle, game_options);
+        // game setup done
+
+        // setup to move orange to its orange door (one move from starting pos)
+        let dest_position = super::MapPosition { x: 2, y: 0 };
+        let test_move = super::Move {
+            heister_color: HeisterColor::Orange,
+            position: dest_position,
+        };
+        let message = MainMessage {
+            body: Some(super::Body::Move(test_move.to_proto())),
+        };
+        let validity = game.handle_message(message);
+        assert_eq!(validity, super::MoveValidity::Valid);
+        let expected_orange_door_loc = super::MapPosition { x: 2, y: 0 };
+        let actual_orange = game
+            .get_heister_from_vec(super::HeisterColor::Orange)
+            .unwrap();
+        let actual_orange_loc = &actual_orange.map_position;
+        assert_eq!(&expected_orange_door_loc, actual_orange_loc);
+        // orange movement done
+
+        // Let's create & execute the tile placement move
+        let tile_entrance = super::MapPosition { x: 2, y: -1 };
+        let test_tile_placement = super::PlaceTile { tile_entrance };
+        let message = MainMessage {
+            body: Some(super::Body::PlaceTile(test_tile_placement.to_proto())),
+        };
+        let validity = game.handle_message(message);
+        assert_eq!(validity, super::MoveValidity::Valid);
+
+        for tile in game.game_state.tiles {
+            if tile.name == "1a".to_string() {
+                let mp_00 = MapPosition { x: 0, y: 0 };
+                assert_eq!(tile.position, mp_00);
+            } else {
+                // No matter the tile name, if we use this path to draw it, its
+                // position should be here.
+                let mp_1neg3 = MapPosition { x: 1, y: -4 };
+                assert_eq!(tile.position, mp_1neg3);
+            }
+        }
     }
 }

--- a/src/load_map.rs
+++ b/src/load_map.rs
@@ -3,17 +3,19 @@
 use crate::types::{MapPosition, SerializableTile, Square, SquareType, Tile, WallType};
 use log::info;
 use serde_json::json;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-pub fn load_tiles_from_json() -> HashMap<String, Tile> {
-    // TODO
+/// This is the default deck function, so far.
+/// Should return all tiles for a default game, minus the starting tile
+/// Because right now we always start with tile_1a hardcoded.
+pub fn load_tiles_from_json() -> Vec<Tile> {
+    // TODO: shuffle tiles?
+    // TODO - finish transcribing all the tiles AND ensure they're oriented correctly
     // Ideally takes a path (like data/tiles/), and returns a hashmap of Tiles
-    let mut tile_map: HashMap<String, Tile> = HashMap::new();
-    tile_map.insert("1a".to_string(), tile_1a());
-    tile_map.insert("2".to_string(), tile_2());
+    let mut tile_map: Vec<Tile> = Vec::new();
+    tile_map.push(tile_2());
     tile_map
 }
 

--- a/src/load_map.rs
+++ b/src/load_map.rs
@@ -11,7 +11,9 @@ use std::path::Path;
 pub fn load_tiles_from_json() -> HashMap<String, Tile> {
     // TODO
     // Ideally takes a path (like data/tiles/), and returns a hashmap of Tiles
-    let tile_map: HashMap<String, Tile> = HashMap::new();
+    let mut tile_map: HashMap<String, Tile> = HashMap::new();
+    tile_map.insert("1a".to_string(), tile_1a());
+    tile_map.insert("2".to_string(), tile_2());
     tile_map
 }
 
@@ -172,7 +174,7 @@ pub fn tile_1a() -> Tile {
 }
 
 pub fn tile_2() -> Tile {
-    // Generate the object for Tile 1a
+    // Generate the object for Tile 2
     let mut my_squares: Vec<Square> = Vec::new();
     let sq00 = Square {
         north_wall: WallType::Impassable,

--- a/src/types.proto
+++ b/src/types.proto
@@ -173,6 +173,11 @@ message Move {
   MapPosition position = 2;
 }
 
+message PlaceTile {
+ // This position is the MapPosition of the square where heisters enter the new tile
+  MapPosition tile_entrance = 1;
+}
+
 // The server returns this when the client tries to do something invalid.
 message InvalidRequest {
   string reason = 1;
@@ -184,5 +189,6 @@ message MainMessage {
     GameState game_state = 1;
     InvalidRequest invalid_request = 2;
     Move move = 3;
+    PlaceTile place_tile = 4;
   }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,8 +3,8 @@ use crate::manager::GameHandle;
 use crate::utils::get_current_time_secs;
 
 use serde::{Deserialize, Serialize};
-use std::convert::From;
 use std::collections::HashMap;
+use std::convert::From;
 // TEMP TODO
 use log::info;
 
@@ -170,7 +170,7 @@ impl Tile {
 
     pub fn to_matrix(&self) -> Vec<Vec<Square>> {
         let temp_sq = Square::default();
-        let mut m: Vec::<Vec::<Square>> = vec![vec![temp_sq; 4]; 4];
+        let mut m: Vec<Vec<Square>> = vec![vec![temp_sq; 4]; 4];
         let mut i = 0;
         for row in 0..4 {
             for col in 0..4 {
@@ -205,10 +205,10 @@ impl Tile {
         let x = 2;
         let y = n - 1;
         let temp_sq = Square::default();
-        let mut rotated: Vec::<Vec::<Square>> = vec![vec![temp_sq; n]; n];
+        let mut rotated: Vec<Vec<Square>> = vec![vec![temp_sq; n]; n];
 
-        for a in 0..(x+1) {
-            for b in a..(y-a+1) {
+        for a in 0..(x + 1) {
+            for b in a..(y - a + 1) {
                 let k = m[a][b];
                 rotated[a][b] = m[y - b][a].rotate_clockwise();
                 rotated[y - b][a] = m[y - a][y - b].rotate_clockwise();
@@ -303,7 +303,7 @@ impl Square {
         rotated_clockwise_90degrees
     }
 
-    pub fn get_walls(&self) -> HashMap::<MoveDirection, WallType> {
+    pub fn get_walls(&self) -> HashMap<MoveDirection, WallType> {
         let mut walls: HashMap<MoveDirection, WallType> = HashMap::new();
         walls.insert(MoveDirection::North, self.north_wall);
         walls.insert(MoveDirection::East, self.east_wall);
@@ -636,8 +636,6 @@ impl Internal for PlaceTile {
     }
 }
 
-
-
 // JSON Serialization for Tiles
 // Since we can't directly add these derives on the proto_types
 #[derive(Serialize, Deserialize)]
@@ -684,9 +682,9 @@ impl From<Tile> for SerializableTile {
 
 #[allow(dead_code, unused_imports)]
 mod tests {
-    use serde_json;
+    use super::{Square, Tile};
     use crate::load_map::tile_1a;
-    use super::{Tile, Square};
+    use serde_json;
     #[test]
     fn load_map_position() {
         let map_position_json = "{\"x\":3,\"y\":5}";

--- a/src/types.rs
+++ b/src/types.rs
@@ -324,7 +324,6 @@ impl Square {
             WallType::OrangeDoor => "O".to_string(),
             WallType::YellowDoor => "Y".to_string(),
             WallType::GreenDoor => "G".to_string(),
-            WallType::Entrance => "v".to_string(),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,8 +5,6 @@ use crate::utils::get_current_time_secs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::From;
-// TEMP TODO
-use log::info;
 
 // Import all the proto types in this private module.
 mod proto_types {
@@ -186,8 +184,6 @@ impl Tile {
                 i += 1;
             }
         }
-        info!("{:?}", m);
-        info!("len {:?}", m.len());
         m
     }
 
@@ -199,7 +195,6 @@ impl Tile {
                 squares.push(*square);
             }
         }
-        info!("Size of squares: expected 16 - {}", squares.len());
         Tile {
             position,
             squares,
@@ -223,7 +218,6 @@ impl Tile {
                 rotated[b][y - a] = k.rotate_clockwise();
             }
         }
-        info!("{:?}", rotated);
         rotated
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,13 @@ pub trait Internal {
     fn to_proto(&self) -> Self::P;
 }
 
+pub const DOOR_TYPES: [&'static WallType; 4] = [
+    &WallType::PurpleDoor,
+    &WallType::OrangeDoor,
+    &WallType::GreenDoor,
+    &WallType::YellowDoor,
+];
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TilePosition {
     x: u32,


### PR DESCRIPTION
OK, this is a biggie.

Things we have in here:

1. PlaceTile message type
  * takes only a MapPosition
2. Tile & Square rotation
  * shout out to stack overflow for matrix rotation tools.
3. Actual Tile Placement logic
  * how it works:
    * check if any heisters are at matching doors
    * if so, figure out what direction they'd be dropping the new tile in
    * draw the new tile (currently, the deck only contains tiles 1a and 2)
    * based on the direction of the new placement, figure out: necessary rotations, and new tile top corner position
    * add tile to game_state.tiles
4. Unit test for having Orange move one square north, and sending a PlaceTile message with the tile entrance that Orange would like to move into/place the tile on.