### PR TITLE
Add possible_placements (for new tiles) to GameState

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -309,6 +309,17 @@ impl Game {
         tile_entrance_positions
     }
 
+    fn update_possible_placements(&mut self) -> () {
+        let grid = self.get_absolute_grid();
+        let heister_to_tile_entrance_locs = self.heister_to_tile_entrance_positions(&grid);
+
+        let mut v = Vec::new();
+        for val in heister_to_tile_entrance_locs.values() {
+            v.push(val.clone());
+        }
+        self.game_state.possible_placements = v.clone();
+    }
+
     fn new_tile_position(position: &MapPosition, dir: &MoveDirection) -> MapPosition {
         // From a tile entrance and move direction of the tile's orientation,
         // return the MapPosition for that new tile to place it in the absolute grid
@@ -364,6 +375,7 @@ impl Game {
                     .get_mut_heister_from_vec(heister_color.clone())
                     .unwrap();
                 heister.map_position = dest_pos;
+                self.update_possible_placements();
             }
             validity
         } else {
@@ -425,7 +437,9 @@ impl Game {
         let dir = &Self::get_door_direction(heister_square)
             .expect("Heister must be on a square with a door");
 
-        self.place_tile(&pt.tile_entrance, dir)
+        let validity = self.place_tile(&pt.tile_entrance, dir);
+        self.update_possible_placements();
+        validity
     }
 
     pub fn handle_message(&mut self, message: MainMessage) -> MoveValidity {

--- a/src/game.rs
+++ b/src/game.rs
@@ -317,7 +317,7 @@ impl Game {
         for val in heister_to_tile_entrance_locs.values() {
             v.push(val.clone());
         }
-        self.game_state.possible_placements = v.clone();
+        self.game_state.possible_placements = v;
     }
 
     fn new_tile_position(position: &MapPosition, dir: &MoveDirection) -> MapPosition {
@@ -375,7 +375,6 @@ impl Game {
                     .get_mut_heister_from_vec(heister_color.clone())
                     .unwrap();
                 heister.map_position = dest_pos;
-                self.update_possible_placements();
             }
             validity
         } else {
@@ -437,9 +436,7 @@ impl Game {
         let dir = &Self::get_door_direction(heister_square)
             .expect("Heister must be on a square with a door");
 
-        let validity = self.place_tile(&pt.tile_entrance, dir);
-        self.update_possible_placements();
-        validity
+        self.place_tile(&pt.tile_entrance, dir);
     }
 
     pub fn handle_message(&mut self, message: MainMessage) -> MoveValidity {
@@ -456,6 +453,7 @@ impl Game {
                 MoveValidity::Invalid("InvalidRequest Message is invalid from players".to_string())
             }
         };
+        self.update_possible_placements();
         validity
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -436,7 +436,7 @@ impl Game {
         let dir = &Self::get_door_direction(heister_square)
             .expect("Heister must be on a square with a door");
 
-        self.place_tile(&pt.tile_entrance, dir);
+        self.place_tile(&pt.tile_entrance, dir)
     }
 
     pub fn handle_message(&mut self, message: MainMessage) -> MoveValidity {

--- a/src/types.proto
+++ b/src/types.proto
@@ -166,6 +166,9 @@ message GameState {
 
   // Players connected to the game.
   repeated Player players = 9;
+
+  // Possible tile entrances for placing new tiles
+  repeated MapPosition possible_placements = 10;
 }
 
 message Move {

--- a/src/types.rs
+++ b/src/types.rs
@@ -500,6 +500,7 @@ pub struct GameState {
     pub remaining_tiles: u32,
     pub game_status: GameStatus,
     pub players: Vec<Player>,
+    pub possible_placements: Vec<MapPosition>,
 }
 
 impl Internal for GameState {
@@ -523,6 +524,11 @@ impl Internal for GameState {
             .map(|p| Player::from_proto(p.clone()))
             .collect();
         let game_status = GameStatus::from_i32(proto.game_status).unwrap(); // TODO Handle this gracefully?
+        let possible_placements = proto
+            .possible_placements
+            .iter()
+            .map(|pp| MapPosition::from_proto(pp.clone()))
+            .collect();
         GameState {
             game_name,
             game_started: proto.game_started,
@@ -533,6 +539,7 @@ impl Internal for GameState {
             remaining_tiles: proto.remaining_tiles,
             game_status,
             players,
+            possible_placements,
         }
     }
 
@@ -540,6 +547,11 @@ impl Internal for GameState {
         let tiles = self.tiles.iter().map(|t| t.to_proto()).collect();
         let heisters = self.heisters.iter().map(|h| h.to_proto()).collect();
         let players = self.players.iter().map(|p| p.to_proto()).collect();
+        let possible_placements = self
+            .possible_placements
+            .iter()
+            .map(|pp| pp.to_proto())
+            .collect();
         let game_status = i32::from(self.game_status);
         proto_types::GameState {
             game_name: self.game_name.0.to_string(),
@@ -551,6 +563,7 @@ impl Internal for GameState {
             remaining_tiles: self.remaining_tiles,
             game_status,
             players,
+            possible_placements,
         }
     }
 }
@@ -581,6 +594,7 @@ impl GameState {
             HeisterColor::Orange,
             &starting_tile_enum,
         ));
+        let possible_placements: Vec<MapPosition> = Vec::new();
         GameState {
             game_name,
             game_started,
@@ -591,6 +605,7 @@ impl GameState {
             remaining_tiles: 8,
             game_status: GameStatus::Staging,
             players: vec![],
+            possible_placements,
         }
     }
 }


### PR DESCRIPTION
Looks pretty legit.


If I move Orange and Purple to valid doors on tile1a in the ui, check this out:

```
Updating game state to 
{…}
​
allItemsTaken: false
​
gameName: "yolo"
​
gameStarted: 1592973633
​
gameStatus: 0
​
heistersList: Array(4) [ {…}, {…}, {…}, … ]
​
playersList: Array [ {…} ]
​
possiblePlacementsList: Array [ {…}, {…} ]
​
remainingTiles: 8
​
tilesList: Array [ {…} ]
​
timerRunsOut: 1592973933
​
<prototype>: Object { … }
slice.ts:115:16
```


And see if I move one away:
```
Updating game state to 
{…}
​
allItemsTaken: false
​
gameName: "yolo"
​
gameStarted: 1592973633
​
gameStatus: 0
​
heistersList: Array(4) [ {…}, {…}, {…}, … ]
​
playersList: Array [ {…} ]
​
possiblePlacementsList: (1) […]
​​
0: Object { x: 2, y: -1 }
​​
length: 1
​​
<prototype>: Array []
​
remainingTiles: 8
​
tilesList: Array [ {…} ]
​
timerRunsOut: 1592973933
​
<prototype>: Object { … }
slice.ts:115:16
```