### PR TITLE
Less strict escalator distance checks

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -211,11 +211,11 @@ impl Game {
     fn get_tile_from_position(&self, position: &MapPosition) -> Option<Tile> {
         for t in &self.game_state.tiles {
             let x_distance = position.x - t.position.x;
-            let x_distance_within_tile = x_distance > 0 && x_distance < 4;
+            let x_distance_within_tile = x_distance >= 0 && x_distance < 4;
             match x_distance_within_tile {
                 true => {
                     let y_distance = position.y - t.position.y;
-                    let y_distance_within_tile = y_distance > 0 && y_distance < 4;
+                    let y_distance_within_tile = y_distance >= 0 && y_distance < 4;
                     match y_distance_within_tile {
                         true => return Some(t.clone()),
                         false => continue,


### PR DESCRIPTION
I think a couple things are iffy here. I should probably write unit tests, but I don't want to yet.

This is making it so that if you're at square 0,0 of a tile, and you are on an escalator, it should return true for letting you go to that escalator, given you satisfy all the other escalator requirements.
//shrug.