### PR TITLE
Aggressively improve frontend performance

### DIFF
--- a/ui/generate_types.sh
+++ b/ui/generate_types.sh
@@ -4,8 +4,6 @@ export PROTOC_GEN_TS_PATH="./node_modules/.bin/protoc-gen-ts"
 # Directory to write generated code to (.js and .d.ts files)
 export OUT_DIR="./src/generated"
 
-ls $PROTOC_GEN_TS_PATH
-
 protoc \
     --plugin="protoc-gen-ts=${PROTOC_GEN_TS_PATH}" \
     --js_out="import_style=commonjs,binary:${OUT_DIR}" \

--- a/ui/src/join_game/GameWindowComponent.tsx
+++ b/ui/src/join_game/GameWindowComponent.tsx
@@ -134,6 +134,7 @@ const Tile = ({
         x={canvas_position.x}
         y={canvas_position.y}
         rotation={num_rotations * 90}
+        perfectDrawEnabled={false}
       />
     );
   } else if (status === "loading") {
@@ -208,7 +209,6 @@ const Heister = ({ proto_heister }: HeisterProps) => {
 
   return (
     <Circle
-      shadowBlur={1}
       x={canvas_position.x + random_x}
       y={canvas_position.y + random_y}
       stroke="black"
@@ -219,6 +219,7 @@ const Heister = ({ proto_heister }: HeisterProps) => {
       offsetY={offset}
       draggable={true}
       onDragEnd={onDragEnd}
+      perfectDrawEnabled={false}
     />
   );
 };
@@ -279,6 +280,7 @@ const PossiblePlacement = ({ map_position }: PossiblePlacementProps) => {
       shadowBlur={5}
       shadowColor="black"
       shadowEnabled={shadowEnabled}
+      perfectDrawEnabled={false}
     />
   );
 };
@@ -385,6 +387,8 @@ const GameWindowComponent = () => {
   // There are two stages. The first here is for things that should move when
   // move "the map". The second is for overlay elements that shouldn't move
   // even when the user drags the map around.
+
+  // We set `listening={false}` on Layers that don't need to receive clicks.
   return (
     <div>
       <div style={styles.gameWindowComponent}>
@@ -397,10 +401,14 @@ const GameWindowComponent = () => {
             draggable={true}
             transformsEnabled={"position"}
           >
-            <Layer>
+            <Layer listening={false}>
               <ShadowTiles shadow_tiles={shadow_tiles} />
               <Tiles tiles={tiles} />
+            </Layer>
+            <Layer>
               <Heisters heisters={getHeisters()} />
+            </Layer>
+            <Layer>
               <PossiblePlacements
                 possible_placements={getPossiblePlacements()}
               />
@@ -448,7 +456,7 @@ const GameWindowComponent = () => {
             draggable={false}
             transformsEnabled={"none"}
           >
-            <Layer>
+            <Layer listening={false}>
               <Provider store={store}>
                 <ActiveHeisterKeyboardComponent
                   x={YELLOW_HEISTER_KEYBOARD_ICON}

--- a/ui/src/join_game/helpers.ts
+++ b/ui/src/join_game/helpers.ts
@@ -114,7 +114,7 @@ export function useWindowDimensions() {
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  });
 
   return windowDimensions;
 }

--- a/ui/src/join_game/overlay_components.tsx
+++ b/ui/src/join_game/overlay_components.tsx
@@ -31,6 +31,10 @@ export const ActiveHeisterKeyboardComponent = ({
   const heister_selected = useSelector(heisterSelectedSelector);
 
   const color = getColor(heister_color);
+
+  // Pretty sure this is the only component that needs
+  // perfectDrawEnabled to be true (which is the default).
+  // Without it, the circle looks weird.
   return (
     <Circle
       x={x}
@@ -42,6 +46,7 @@ export const ActiveHeisterKeyboardComponent = ({
       shadowBlur={8}
       shadowColor="black"
       shadowEnabled={heister_color === heister_selected}
+      perfectDrawEnabled={true}
     />
   );
 };

--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
+    <meta name="viewport" content="width=device-width, initial-scale=0.65, maximum-scale=1, user-scalable=no">
     <title>Team Heist Tactics</title>
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/normalize.css/normalize.css" />
     <link href="https://fonts.googleapis.com/css2?family=Damion&display=swap" rel="stylesheet">


### PR DESCRIPTION
I essentially followed this guide: https://konvajs.org/docs/performance/All_Performance_Tips.html.

But in the end, the thing that was murdering performance on Firefox was drawing the shadows around the heisters.

Other things I did:
- Separate unrelated components into separate layers, to avoid full layer redraw when any one of them changes.
- Turn off perfectDrawEnabled for most canvas elements. Only the keyboard heister icons in the top left look weird without it.
- Stop layers from listening that don't need to be. This is faster because we don't have to create the hit boxes for those elements.
- Not necessarily perf related, but I made the scale better on mobile, so it isn't so zoomed in.
- I made it easier to avoid the bug on iPhone where the canvas viewport doesn't match the window by making it not zoom in on the form when you try to edit one of the text fields. If the user zooms in on their own before joining game though, this issue will still present itself. See #58 for more.