### PR TITLE
Implement Server-Side Teleport Move

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -606,8 +606,13 @@ impl Game {
                 }
                 validity
             }
-            // Not escalator, not teleporter -> try adjacent move check
-            _wildcard => MoveValidity::Invalid("Invalid move".to_string()),
+            _wildcard => {
+                let msg = format!(
+                    "Invalid move for heister {} at {:?} to position {:?}",
+                    heister_color, heister_pos, dest_pos
+                );
+                MoveValidity::Invalid(msg.to_string())
+            }
         }
     }
 


### PR DESCRIPTION
What it says on the tin.

Some refactoring in process_move, so each match has a "validate_x" function that it uses an if on, to determine whether to do the move.

I think using the `if` with a single case that doesn't return is actually cleaner than a match, that's why I'm using it here.

Some other refactoring - passing grid to one of the helper functions, rather than having it recompute the grid.