### PR TITLE
Place tiles, heisters, and possible placements correctly

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -53,3 +53,34 @@ This leads into the next problem, which is the redux-websocket client will try t
 Furthermore, one thing to note is that the event from `onerror` of the websocket doesn't actually say what went wrong, you need to look at the event from `onclose` instead. Not a huge problem, but `redux-websocket` does not include any information about the event on either `error` or `close` in the action it submits.
 
 These are all solvable, but a lot of work.
+
+## Original squareCoordToTileCoord
+
+```
+export const squareCoordtoTileCoord = (
+  // These are from a square, which comes straight from a server MapPosition.
+  square_x: number,
+  square_y: number
+): TileCoords => {
+  // TODO Search outwards from zero instead.
+  for (let tile_x = -20; tile_x <= 20; tile_x++) {
+    for (let tile_y = -20; tile_y <= 20; tile_y++) {
+      var min_x = tile_x * 4 - tile_y;
+      var max_x = tile_x * 4 - tile_y + 3;
+      var min_y = tile_y * 4 + tile_x;
+      var max_y = tile_y * 4 + tile_x + 3;
+      // console.log(`square ${square_x},${square_y} tile ${tile_x},${tile_y} = min: ${min_x},${min_y} max: ${max_x},${max_y}`)
+      if (
+        min_x <= square_x &&
+        square_x <= max_x &&
+        min_y <= square_y &&
+        square_y <= max_y
+      ) {
+        return { x: tile_x, y: tile_y };
+      }
+    }
+  }
+  throw "Couldn't go from square coords to tile coords";
+};
+```
+This 100% works.

--- a/ui/src/join_game/GameWindowComponent.tsx
+++ b/ui/src/join_game/GameWindowComponent.tsx
@@ -54,7 +54,6 @@ const get_tile_and_shadow_tile = ({
 }: GetTileShadowSquareProps) => {
   const size = TILE_SIZE;
   const offset = size / 2;
-  const pixel_offset = -INTERNAL_TILE_OFFSET;
 
   var map_position = proto_tile.getPosition()!;
   var canvas_position = mapPositionToCanvasPosition(
@@ -156,18 +155,13 @@ type HeisterProps = {
 const Heister = ({ proto_heister }: HeisterProps) => {
   const dispatch = useDispatch();
 
-  const offset = HEISTER_SIZE * 1.5 + INTERNAL_SQUARE_SIZE;
-  const pixel_offset = -INTERNAL_SQUARE_SIZE - HEISTER_SIZE * 2 + 3;
+  const heister_color = proto_heister.getHeisterColor();
+  const map_position = proto_heister.getMapPosition()!;
 
   // TODO Don't tell the client the walls unless we wanna do client side validation.
 
-  const heister_color = proto_heister.getHeisterColor();
-  const map_position = proto_heister.getMapPosition()!;
-  // This sort of helped. I think I really just need the position of the tile I am on.
-  // const tile_offset_y = -Math.floor(map_position.getX() / 4);
-  // const tile_offset_x = -Math.floor(map_position.getY() / 4);
-  const tile_offset_x = 0;
-  const tile_offset_y = 0;
+  const pixel_offset = HEISTER_SIZE * 1.5 + INTERNAL_SQUARE_SIZE;
+
   var { width, height } = useWindowDimensions();
   const canvas_position = mapPositionToCanvasPosition(
     map_position,
@@ -175,7 +169,7 @@ const Heister = ({ proto_heister }: HeisterProps) => {
     height
   );
 
-  console.log(
+  console.debug(
     `${heister_color} (0 yellow, 1 purple, 2 green, 3 orange) heister at canvas.x/y ${canvas_position.x} ${canvas_position.y} map ${map_position}`
   );
 
@@ -186,6 +180,7 @@ const Heister = ({ proto_heister }: HeisterProps) => {
     // Pause rendering of this unit until we get information back
     // about whether the move attempt was valid. Otherwise it'll just snap back immediately.
     // Or perhaps until we get new game state back as a stop gap.
+    console.info("event okay", event);
     var x = event.target.x();
     var y = event.target.y();
     console.log("Attempted position ", x, y);
@@ -210,14 +205,12 @@ const Heister = ({ proto_heister }: HeisterProps) => {
 
   return (
     <Circle
-      x={canvas_position.x + random_x}
-      y={canvas_position.y + random_y}
+      x={canvas_position.x - pixel_offset + random_x}
+      y={canvas_position.y - pixel_offset + random_y}
       stroke="black"
       fill={getColor(heister_color)}
       strokeWidth={4}
       radius={HEISTER_SIZE}
-      offsetX={offset}
-      offsetY={offset}
       draggable={true}
       onDragEnd={onDragEnd}
       perfectDrawEnabled={false}
@@ -231,7 +224,7 @@ type PossiblePlacementProps = {
 const PossiblePlacement = ({ map_position }: PossiblePlacementProps) => {
   const dispatch = useDispatch();
 
-  const pixel_offset = -INTERNAL_SQUARE_SIZE;
+  const pixel_offset = INTERNAL_SQUARE_SIZE * 2;
   console.log("pixel offset", pixel_offset);
 
   var { width, height } = useWindowDimensions();
@@ -263,18 +256,15 @@ const PossiblePlacement = ({ map_position }: PossiblePlacementProps) => {
 
   return (
     <Rect
-      x={canvas_position.x}
-      y={canvas_position.y}
+      x={canvas_position.x - pixel_offset}
+      y={canvas_position.y - pixel_offset}
       width={INTERNAL_SQUARE_SIZE}
       height={INTERNAL_SQUARE_SIZE}
       stroke="black"
       strokeWidth={stroke_width}
-      offsetX={INTERNAL_SQUARE_SIZE * 2}
-      offsetY={INTERNAL_SQUARE_SIZE * 2}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onClick={onClick}
-      // fill={colors.background}
       shadowBlur={5}
       shadowColor="black"
       shadowEnabled={shadowEnabled}

--- a/ui/src/join_game/GameWindowComponent.tsx
+++ b/ui/src/join_game/GameWindowComponent.tsx
@@ -59,9 +59,6 @@ const get_tile_and_shadow_tile = ({
   var map_position = proto_tile.getPosition()!;
   var canvas_position = mapPositionToCanvasPosition(
     map_position,
-    pixel_offset,
-    1,
-    3,
     width,
     height
   );
@@ -159,7 +156,7 @@ type HeisterProps = {
 const Heister = ({ proto_heister }: HeisterProps) => {
   const dispatch = useDispatch();
 
-  const offset = HEISTER_SIZE;
+  const offset = HEISTER_SIZE * 1.5 + INTERNAL_SQUARE_SIZE;
   const pixel_offset = -INTERNAL_SQUARE_SIZE - HEISTER_SIZE * 2 + 3;
 
   // TODO Don't tell the client the walls unless we wanna do client side validation.
@@ -174,9 +171,6 @@ const Heister = ({ proto_heister }: HeisterProps) => {
   var { width, height } = useWindowDimensions();
   const canvas_position = mapPositionToCanvasPosition(
     map_position,
-    pixel_offset,
-    tile_offset_x,
-    tile_offset_y,
     width,
     height
   );
@@ -237,15 +231,12 @@ type PossiblePlacementProps = {
 const PossiblePlacement = ({ map_position }: PossiblePlacementProps) => {
   const dispatch = useDispatch();
 
-  const pixel_offset = -INTERNAL_SQUARE_SIZE * 2.2;
+  const pixel_offset = -INTERNAL_SQUARE_SIZE;
   console.log("pixel offset", pixel_offset);
 
   var { width, height } = useWindowDimensions();
   const canvas_position = mapPositionToCanvasPosition(
     map_position,
-    pixel_offset,
-    0,
-    0,
     width,
     height
   );
@@ -278,8 +269,8 @@ const PossiblePlacement = ({ map_position }: PossiblePlacementProps) => {
       height={INTERNAL_SQUARE_SIZE}
       stroke="black"
       strokeWidth={stroke_width}
-      offsetX={INTERNAL_SQUARE_SIZE / 4}
-      offsetY={INTERNAL_SQUARE_SIZE / 4}
+      offsetX={INTERNAL_SQUARE_SIZE * 2}
+      offsetY={INTERNAL_SQUARE_SIZE * 2}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onClick={onClick}

--- a/ui/src/join_game/MainPage.tsx
+++ b/ui/src/join_game/MainPage.tsx
@@ -73,7 +73,9 @@ const MainGame = ({}: MainGameProps) => {
     inner = <GameWindowComponent />;
   } else {
     var inner_form;
-    if (connection_status != ConnectionStatus.Connected) {
+    if (connection_status == ConnectionStatus.Connecting) {
+      <p>Joining game...</p>;
+    } else if (connection_status == ConnectionStatus.NotConnected) {
       inner_form = <JoinGameForm />;
     } else if (
       game_state &&

--- a/ui/src/join_game/helpers.spec.ts
+++ b/ui/src/join_game/helpers.spec.ts
@@ -1,6 +1,7 @@
 import {
   canvasPositionToMapPosition,
   mapPositionToCanvasPosition,
+  mapPositionToTileCoords,
 } from "./helpers";
 import { MapPosition } from "../generated/types_pb";
 import {
@@ -254,4 +255,135 @@ test("doors align y-axis on western draw", () => {
   ); // west door on this tile
 
   expect(tile_east_door_yval).toBe(tile_center_east_door_yval);
+});
+
+test("tile position function is correct", () => {
+  return;
+  // Test the base tile.
+  var mp = new MapPosition();
+  mp.setX(0);
+  mp.setY(0);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(3);
+  mp.setY(0);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(0);
+  mp.setY(3);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(3);
+  mp.setY(3);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+
+  // Test the null zones around the base tile.
+  // These are map positions that are impossible for a tile to have squares on.
+  // These go from above 0,0 (top left) clockwise.
+  /*
+  var mp = new MapPosition();
+  mp.setX(0);
+  mp.setY(-1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
+
+  var mp = new MapPosition();
+  mp.setX(4);
+  mp.setY(0);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
+
+  var mp = new MapPosition();
+  mp.setX(3);
+  mp.setY(4);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
+
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(3);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
+  */
+
+  // Test positions of the tile right from the start tile.
+  // Top left corner and then clockwise.
+  var mp = new MapPosition();
+  var mp = new MapPosition();
+  mp.setX(4);
+  mp.setY(1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(7);
+  mp.setY(1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(7);
+  mp.setY(4);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(4);
+  mp.setY(4);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+
+  // Test positions of the tile left from the start tile.
+  // First the direction entrance, and then the top left corner and clockwise.
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(-4);
+  mp.setY(-1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(-1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(2);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+
+  var mp = new MapPosition();
+  mp.setX(-4);
+  mp.setY(2);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+
+  /*
+  var mp = new MapPosition();
+  mp.setX(-4);
+  mp.setY(-1);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: -1, y: 0});
+
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(4);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 0, y: 1});
+
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(7);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 0, y: 1});
+
+  var mp = new MapPosition();
+  mp.setX(3);
+  mp.setY(4);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 1, y: 1});
+
+  var mp = new MapPosition();
+  mp.setX(3);
+  mp.setY(7);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 1, y: 1});
+
+  var mp = new MapPosition();
+  mp.setX(-1);
+  mp.setY(2);
+  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: -1, y: 0});
+  */
 });

--- a/ui/src/join_game/helpers.spec.ts
+++ b/ui/src/join_game/helpers.spec.ts
@@ -1,7 +1,7 @@
 import {
   canvasPositionToMapPosition,
   mapPositionToCanvasPosition,
-  mapPositionToTileCoords,
+  squareCoordstoTileCoords,
 } from "./helpers";
 import { MapPosition } from "../generated/types_pb";
 import {
@@ -25,14 +25,7 @@ test("tile placement map_position reversible translations", () => {
   let center = new MapPosition();
   center.setX(0);
   center.setY(0);
-  let a = mapPositionToCanvasPosition(
-    center,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  let a = mapPositionToCanvasPosition(center, CANVAS_WIDTH, CANVAS_HEIGHT);
   expect(a.x).toBe(800);
   expect(a.y).toBe(500);
   let b = canvasPositionToMapPosition(
@@ -50,14 +43,7 @@ test("tile 1,-4 map_position reversible translation", () => {
   let tile_corner = new MapPosition();
   tile_corner.setX(1);
   tile_corner.setY(-4);
-  let a = mapPositionToCanvasPosition(
-    tile_corner,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  let a = mapPositionToCanvasPosition(tile_corner, CANVAS_WIDTH, CANVAS_HEIGHT);
   // For this simple case, I can guess what the resulting canvas value is. TODO - is this assumption correct?
   expect(a.x).toBe(CANVAS_WIDTH / 2 + INTERNAL_SQUARE_SIZE);
   expect(a.y).toBe(CANVAS_HEIGHT / 2 - TILE_SIZE);
@@ -72,18 +58,10 @@ test("tile 1,-4 map_position reversible translation", () => {
 });
 
 test("tile -1,4 map_position reversible translation", () => {
-  let pixel_offset = 0;
   let tile_corner = new MapPosition();
   tile_corner.setX(-1);
   tile_corner.setY(4);
-  let a = mapPositionToCanvasPosition(
-    tile_corner,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  let a = mapPositionToCanvasPosition(tile_corner, CANVAS_WIDTH, CANVAS_HEIGHT);
   // expect(a.x).toBe(CANVAS_WIDTH / 2 - INTERNAL_SQUARE_SIZE); // -- BROKEN
   expect(a.y).toBe(CANVAS_HEIGHT / 2 + TILE_SIZE);
   let b = canvasPositionToMapPosition(
@@ -97,18 +75,10 @@ test("tile -1,4 map_position reversible translation", () => {
 });
 
 test("tile -4,-1 map_position reversible translation", () => {
-  let pixel_offset = 0;
   let tile_corner = new MapPosition();
   tile_corner.setX(-4);
   tile_corner.setY(-1);
-  let a = mapPositionToCanvasPosition(
-    tile_corner,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  let a = mapPositionToCanvasPosition(tile_corner, CANVAS_WIDTH, CANVAS_HEIGHT);
   expect(a.x).toBe(
     CANVAS_WIDTH / 2 - (2 * INTERNAL_TILE_OFFSET + 4 * INTERNAL_SQUARE_SIZE)
   );
@@ -130,14 +100,7 @@ test("tile 4,1 map_position reversible translation", () => {
   let tile_corner = new MapPosition();
   tile_corner.setX(4);
   tile_corner.setY(1);
-  let a = mapPositionToCanvasPosition(
-    tile_corner,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  let a = mapPositionToCanvasPosition(tile_corner, CANVAS_WIDTH, CANVAS_HEIGHT);
   expect(a.x).toBe(
     CANVAS_WIDTH / 2 + (2 * INTERNAL_TILE_OFFSET + 4 * INTERNAL_SQUARE_SIZE)
   );
@@ -153,18 +116,10 @@ test("tile 4,1 map_position reversible translation", () => {
 });
 
 test("tile 4,-16 map_position reversible translation", () => {
-  let pixel_offset = 0;
   let tile_corner = new MapPosition();
   tile_corner.setX(4);
   tile_corner.setY(-16);
-  let a = mapPositionToCanvasPosition(
-    tile_corner,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  let a = mapPositionToCanvasPosition(tile_corner, CANVAS_WIDTH, CANVAS_HEIGHT);
   let b = canvasPositionToMapPosition(
     a,
     pixel_offset,
@@ -178,18 +133,10 @@ test("tile 4,-16 map_position reversible translation", () => {
 test("map position translation in both directions at non-center should work, too", () => {
   // NOTE: TODO: This fails at big numbers (251 and 252).
   // Unit test of sorts.
-  let pixel_offset = 20;
   var mp = new MapPosition();
   mp.setX(1);
   mp.setY(2);
-  var a = mapPositionToCanvasPosition(
-    mp,
-    pixel_offset,
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  var a = mapPositionToCanvasPosition(mp, CANVAS_WIDTH, CANVAS_HEIGHT);
   var b = canvasPositionToMapPosition(
     a,
     pixel_offset,
@@ -204,14 +151,7 @@ test("doors align y-axis on western draw", () => {
   var mp = new MapPosition();
   mp.setX(0);
   mp.setY(0);
-  var tile00_pos = mapPositionToCanvasPosition(
-    mp,
-    0, // pixel offset is 0
-    0,
-    0,
-    CANVAS_WIDTH,
-    CANVAS_HEIGHT
-  );
+  var tile00_pos = mapPositionToCanvasPosition(mp, CANVAS_WIDTH, CANVAS_HEIGHT);
   var tile_center_west_door_val = get_door_canvas_yval_from_tile_corner(
     tile00_pos,
     2
@@ -226,9 +166,6 @@ test("doors align y-axis on western draw", () => {
   west_door_first_tile.setY(-1);
   var tile_west = mapPositionToCanvasPosition(
     west_door_first_tile,
-    0,
-    0,
-    0,
     CANVAS_WIDTH,
     CANVAS_HEIGHT
   );
@@ -243,9 +180,6 @@ test("doors align y-axis on western draw", () => {
   east_door_first_tile.setY(1);
   var tile_east_pos = mapPositionToCanvasPosition(
     east_door_first_tile,
-    0,
-    0,
-    0,
     CANVAS_WIDTH,
     CANVAS_HEIGHT
   );
@@ -257,133 +191,57 @@ test("doors align y-axis on western draw", () => {
   expect(tile_east_door_yval).toBe(tile_center_east_door_yval);
 });
 
-test("tile position function is correct", () => {
-  return;
+test("test squareCoordstoTileCoords is correct", () => {
   // Test the base tile.
-  var mp = new MapPosition();
-  mp.setX(0);
-  mp.setY(0);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+  expect(squareCoordstoTileCoords(0, 0)).toStrictEqual({ x: 0, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(3);
-  mp.setY(0);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+  expect(squareCoordstoTileCoords(3, 0)).toStrictEqual({ x: 0, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(0);
-  mp.setY(3);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
+  expect(squareCoordstoTileCoords(0, 3)).toStrictEqual({ x: 0, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(3);
-  mp.setY(3);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 0, y: 0 });
-
-  // Test the null zones around the base tile.
-  // These are map positions that are impossible for a tile to have squares on.
-  // These go from above 0,0 (top left) clockwise.
-  /*
-  var mp = new MapPosition();
-  mp.setX(0);
-  mp.setY(-1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
-
-  var mp = new MapPosition();
-  mp.setX(4);
-  mp.setY(0);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
-
-  var mp = new MapPosition();
-  mp.setX(3);
-  mp.setY(4);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
-
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(3);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual(null);
-  */
+  expect(squareCoordstoTileCoords(3, 3)).toStrictEqual({ x: 0, y: 0 });
 
   // Test positions of the tile right from the start tile.
   // Top left corner and then clockwise.
-  var mp = new MapPosition();
-  var mp = new MapPosition();
-  mp.setX(4);
-  mp.setY(1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+  expect(squareCoordstoTileCoords(4, 1)).toStrictEqual({ x: 1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(7);
-  mp.setY(1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+  expect(squareCoordstoTileCoords(7, 1)).toStrictEqual({ x: 1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(7);
-  mp.setY(4);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+  expect(squareCoordstoTileCoords(7, 4)).toStrictEqual({ x: 1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(4);
-  mp.setY(4);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: 1, y: 0 });
+  expect(squareCoordstoTileCoords(4, 4)).toStrictEqual({ x: 1, y: 0 });
 
   // Test positions of the tile left from the start tile.
   // First the direction entrance, and then the top left corner and clockwise.
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+  expect(squareCoordstoTileCoords(-1, 1)).toStrictEqual({ x: -1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(-4);
-  mp.setY(-1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+  expect(squareCoordstoTileCoords(-4, -1)).toStrictEqual({ x: -1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(-1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+  expect(squareCoordstoTileCoords(-1, -1)).toStrictEqual({ x: -1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(2);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+  expect(squareCoordstoTileCoords(-1, 2)).toStrictEqual({ x: -1, y: 0 });
 
-  var mp = new MapPosition();
-  mp.setX(-4);
-  mp.setY(2);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({ x: -1, y: 0 });
+  expect(squareCoordstoTileCoords(-4, 2)).toStrictEqual({ x: -1, y: 0 });
 
-  /*
-  var mp = new MapPosition();
-  mp.setX(-4);
-  mp.setY(-1);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: -1, y: 0});
+  // Test positions of the tile down from the start tile.
+  // First the direction entrance, and then the top left corner and clockwise.
+  expect(squareCoordstoTileCoords(1, 4)).toStrictEqual({ x: 0, y: 1 });
 
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(4);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 0, y: 1});
+  expect(squareCoordstoTileCoords(-1, 4)).toStrictEqual({ x: 0, y: 1 });
 
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(7);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 0, y: 1});
+  expect(squareCoordstoTileCoords(2, 4)).toStrictEqual({ x: 0, y: 1 });
 
-  var mp = new MapPosition();
-  mp.setX(3);
-  mp.setY(4);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 1, y: 1});
+  expect(squareCoordstoTileCoords(2, 7)).toStrictEqual({ x: 0, y: 1 });
 
-  var mp = new MapPosition();
-  mp.setX(3);
-  mp.setY(7);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: 1, y: 1});
+  expect(squareCoordstoTileCoords(-1, 7)).toStrictEqual({ x: 0, y: 1 });
 
-  var mp = new MapPosition();
-  mp.setX(-1);
-  mp.setY(2);
-  expect(mapPositionToTileCoords(mp)).toStrictEqual({x: -1, y: 0});
-  */
+  // Test positions of the tile down TWICE from the start tile.
+  // Top left corner and then clockwise.
+  expect(squareCoordstoTileCoords(-2, 8)).toStrictEqual({ x: 0, y: 2 });
+
+  expect(squareCoordstoTileCoords(1, 8)).toStrictEqual({ x: 0, y: 2 });
+
+  expect(squareCoordstoTileCoords(1, 11)).toStrictEqual({ x: 0, y: 2 });
+
+  expect(squareCoordstoTileCoords(-2, 8)).toStrictEqual({ x: 0, y: 2 });
 });

--- a/ui/src/join_game/helpers.ts
+++ b/ui/src/join_game/helpers.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from "react";
-import { MapPosition } from "../generated/types_pb";
+import { MapPosition, TilePosition } from "../generated/types_pb";
 import {
   INTERNAL_SQUARE_SIZE,
   INTERNAL_TILE_OFFSET,
   TILE_SIZE,
 } from "../constants/other";
-import { CanvasPosition } from "./types";
+import { CanvasPosition, TileCoords } from "./types";
 
 export const mapPositionToCanvasPositionSingle = (
   n: number,
@@ -47,6 +47,25 @@ export const mapPositionToCanvasPosition = (
     tile_offset_y
   );
   return { x: canvas_x, y: canvas_y };
+};
+
+export const mapPositionToTileCoords = (
+  map_position: MapPosition
+): TileCoords | null => {
+  // This function returns where the tile is on the angled x / y axes.
+  var map_x = map_position.getX();
+  var map_y = map_position.getY();
+  var tile_x = mapPositionToTileCoordSingle(map_x, map_y);
+  var tile_y = mapPositionToTileCoordSingle(map_y, map_x);
+  return { x: tile_x, y: tile_y };
+};
+
+const mapPositionToTileCoordSingle = (
+  main: number,
+  alternate: number
+): number => {
+  let offset = Math.floor(alternate / 4);
+  return Math.floor((main - offset) / 4);
 };
 
 const canvasCoordToMapCoord = (

--- a/ui/src/join_game/helpers.ts
+++ b/ui/src/join_game/helpers.ts
@@ -1,23 +1,26 @@
 import { useState, useEffect } from "react";
-import { MapPosition, TilePosition } from "../generated/types_pb";
+import { MapPosition } from "../generated/types_pb";
 import {
   INTERNAL_SQUARE_SIZE,
   INTERNAL_TILE_OFFSET,
   TILE_SIZE,
 } from "../constants/other";
-import { CanvasPosition, TileCoords } from "./types";
+import { CanvasPosition, SquareCoords, TileCoords } from "./types";
 
 const inclusive_range = (start: number, end: number): number[] => {
   return [...Array(end + 1 - start).keys()].map((i) => i + start);
 };
+
+// The max number of tiles we would have in any direction from the middle.
+const TILES_LENGTH = 50;
 
 // This function precomputes a map of square coords (map positions) to tile coords.
 // Because you can't really use normal objects as keys, I use a string as a key instead.
 // -50 to 50 is total overkill, 25 would be enough, but better safe than sorry.
 const precomputeSquareCoordtoTileCoordMap = (): Map<string, TileCoords> => {
   let map: Map<string, TileCoords> = new Map();
-  for (let tile_x = -50; tile_x <= 50; tile_x++) {
-    for (let tile_y = -50; tile_y <= 50; tile_y++) {
+  for (let tile_x = -TILES_LENGTH; tile_x <= TILES_LENGTH; tile_x++) {
+    for (let tile_y = -TILES_LENGTH; tile_y <= TILES_LENGTH; tile_y++) {
       var min_x = tile_x * 4 - tile_y;
       var max_x = tile_x * 4 - tile_y + 3;
       var min_y = tile_y * 4 + tile_x;

--- a/ui/src/join_game/types.d.ts
+++ b/ui/src/join_game/types.d.ts
@@ -28,6 +28,11 @@ export interface CanvasPosition {
   y: number;
 }
 
+export interface SquareCoords {
+  x: number;
+  y: number;
+}
+
 export interface TileCoords {
   x: number;
   y: number;

--- a/ui/src/join_game/types.d.ts
+++ b/ui/src/join_game/types.d.ts
@@ -27,3 +27,8 @@ export interface CanvasPosition {
   x: number;
   y: number;
 }
+
+export interface TileCoords {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
The key here is that I start with tile -> squares, which turns out to be quite simple, even more so than the formula Max came up with:
```
var min_x = tile_x * 4 - tile_y;
var max_x = tile_x * 4 - tile_y + 3;
var min_y = tile_y * 4 + tile_x;
var max_y = tile_y * 4 + tile_x + 3;
```
These together define all 16 squares on any tile on the map, taking into account how the offsets work as you place additional tiles.

From here, we can create a function that goes from square coord to tile coord just by inverting the results. I don't attempt to invert this function. Instead, I go through all tiles in the -50 to 50 range (larger than it is possible to place tiles) and then put together a map from square coord to tile coord. We can then use this to determine what tile we're on from the MapPosition that every canvas element has (tile, heister, and possible placement).

Once you know what tile you're on, it is easy to figure out where you should place the element on the map. In fact I didn't really have to alter my original function (where I just add up wall and square widths) for this at all:
```
// Get canvas position based on 0,0.
var corner_canvas = tile_n * 2 * INTERNAL_TILE_OFFSET + map_n * INTERNAL_SQUARE_SIZE;
// Move it into the center.
var adjusted_canvas = corner_canvas + canvas_dimension_size_px / 2;
```

The function works for all elements, not just tiles, as long as you use an appropriate offset for the final render (after all of this math takes place), which you can see me adjust in this PR.

There are a bunch of tests that validate that this method is correct.

I haven't yet been able to figure out how to go back the other way, from a canvas coord (canvas pixel) to a map position. I do have a few ideas though:
- Precompute a map from every pixel to a map position.
  - I tried this and it was way too expensive, the browser didn't like it one bit.
  - A way to make this work would be a treemap, where the "key" allows for range searches.
- Precompute a map from specific pixels to a map position. Run the forward function for every possible map position to get canvas coords for each of them. When dropping an element, round it to that pixel somehow.
- Invert the function somehow.
- Figure out which tile you are dropping the heister on, and then use its tile offset to calculate the map position. This would be easy once hooked up, but I'm not sure how to get a reference to a component simply by having another component on top of it.
- Try and "walk" the heister. Get its current map position, then increase x or y, and get the new pixel position. Keep trying this (or perhaps bisect) until you get the map position that is closest to the desired pixel position.

I think we should probably just land this and then try to get the drag and drop working separately.