### PR TITLE
Add possible_teleports to GameState (and revealed_teleports to Game)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,10 @@ fn main() {
         .type_attribute(".types.TilePosition", "#[derive(Serialize, Deserialize)]")
         .type_attribute(".types.HeisterName", "#[derive(Serialize, Deserialize)]")
         .type_attribute(".types.HeisterColor", "#[derive(Serialize, Deserialize)]")
+        .type_attribute(
+            ".types.PossibleTeleportEntry",
+            "#[derive(Serialize, Deserialize)]",
+        )
         .type_attribute(".types.StartGame", "#[derive(Serialize, Deserialize)]")
         .compile_protos(&["src/types.proto"], &["src/"])
         .unwrap();

--- a/src/types.proto
+++ b/src/types.proto
@@ -132,6 +132,13 @@ enum GameStatus {
   DEFEAT = 3;
 }
 
+// We can't have maps of lists in protobuf, so instead we'll have a list of these,
+// and construct a map from that.
+message PossibleTeleportEntry {
+    HeisterColor color = 1;
+    MapPosition position = 2;
+}
+
 // Captures all information related to the game.
 message GameState {
   // Word(s) that points to this game instance.
@@ -166,6 +173,9 @@ message GameState {
 
   // Possible escalator positions a heister can reach via escalator
   map<int32, MapPosition> possible_escalators = 11;
+
+  // Map of possible locations a heister can teleport to
+  repeated PossibleTeleportEntry possible_teleports = 12;
 
 }
 


### PR DESCRIPTION
fix #89 

Things this does...
So the server will keep track of revealed teleporters, as you reveal them.
!!! Important note !!! --- The server assumes there will be at MOST one teleport per color per tile.
!!! Important note !!! --- The update_revealed_teleporters function ASSUMES that the GameState starts with ONE tile in `self.tiles`

Other notes:
* refactors update_auxiliary_state to have one call to `get_absolute_grid` that is shared between each of the update() functions.
* In the protobuf def, you CANNOT have a map of lists. (Which this is.) So instead, we have a list of tuples, color to position, which the server folds into a map properly. This ought to be implemented on the UI side as well, though, I guess it technically doesn't have to be.
* Some strictness around `update_tile_doors` - the logic at that part of `place_tile` is finicky - `update_revealed_teleporters` is expected to be called with a new tile and the self.tiles that do NOT include the new tile. `update_tile_doors` expects the new tile to already have been added. So the order for all these calls is pretty strict. I left that comment there to call it out, in particular.

I doubt it will get any scary changes.

Implementing `update_revealed_teleporters` was actually kind of a pain in the butt (self, &mut self, static method, what to do?!) but it worked out so, who cares.