### PR TITLE
Add mismatched door check for if neighbor has door and new tile does not

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -800,8 +800,7 @@ impl Game {
         let tile = &self.game_state.tiles[tile_idx];
 
         for (dir, position) in tile.adjacent_entrances() {
-            let adjacent_entrance_exists = grid.get(&position);
-            match adjacent_entrance_exists {
+            match grid.get(&position) {
                 Some(neighbor_square) => {
                     let my_door_pos = position.move_in_direction(&dir.opposite());
                     let my_square = grid.get(&my_door_pos).unwrap();
@@ -818,6 +817,14 @@ impl Game {
                             // If there isn't a door on the other side, close door
                             // that way, we know it won't be a possible_placement
                             mut_tile.close_door_in_dir(dir);
+                        }
+                    } else {
+                        // If my square does NOT have a door, but neighbor does
+                        if neighbor_square.has_door() {
+                            let (idx, mut neighbor_tile) =
+                                self.get_tile_with_index(&position).unwrap();
+                            neighbor_tile.close_door_in_dir(dir.opposite());
+                            self.game_state.tiles[idx] = neighbor_tile;
                         }
                     }
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -365,14 +365,12 @@ impl Tile {
     /// 4*   5    6    7
     /// 8    9   10  *11
     /// 12  13*  14   15
-    pub fn get_door_squares(&self) -> HashMap<MoveDirection, Square> {
+    pub fn get_entrance_squares(&self) -> HashMap<MoveDirection, Square> {
         let mut map: HashMap<MoveDirection, Square> = HashMap::new();
         let dirs_to_square_indices = Tile::door_square_indices();
         for (dir, square_index) in dirs_to_square_indices {
             let square = *self.squares.get(square_index).unwrap();
-            if square.has_door() {
-                map.insert(dir, square);
-            }
+            map.insert(dir, square);
         }
         map
     }
@@ -395,9 +393,10 @@ impl Tile {
         square.close_door(dir)
     }
 
+    /// This returns possible entrance positions (not contained by this tile)
     pub fn adjacent_entrances(&self) -> HashMap<MoveDirection, MapPosition> {
         let mut map: HashMap<MoveDirection, MapPosition> = HashMap::new();
-        for dir in self.get_door_squares().keys() {
+        for dir in self.get_entrance_squares().keys() {
             let pos = self.position.entrance_position(dir);
             map.insert(*dir, pos);
         }


### PR DESCRIPTION
close #132

This was just a case that wasn't handled at all. I changed get_door_squares to instead be called get_entrance_squares, because they could be "entrances" as in they are in the classic "entrance" positions, but they do not necessarily have doors on those squares.

Got pretty frustrated why mutating neighbor_tile wasn't enough, but bless up my past self for witing "get_tile_with_index" since that's the only way to actually update self.tiles to have the newly modified tile in it properly.