### PR TITLE
Fix adjacent teleports & add 3 new unit test cases

### DIFF
--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::time::Duration;
 
 use crate::game::GameHandle;
-use crate::manager::{GameManager, GameManagerWrapper, GameWrapper, TEST_HANDLE};
+use crate::manager::{GameManagerWrapper, GameWrapper, TEST_HANDLE};
 use crate::utils::get_current_time_secs;
 
 const REAP_DURATION: u64 = 3600; // 1hr from creation, games are reaped


### PR DESCRIPTION
I'll tell you what's weird and bad about this pull request first:


I restructed process_move differently. The description of the motivation is in the docstring for that function.

HOWEVER...

I set 2 default values at different points.
At the start, I set the default value of "validity" to Valid, so that I can rely on the ternary operators to set invalid with priority.

Once we're done with the match to find "special moves" (escalator, teleport), I set the new default of "validity" to Invalid, so that we can ONLY check for Directional moves IFF none of the special moves were already matched.

fix #153 