### PR TITLE
Have teleports stop working once all items have been taken

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -268,19 +268,16 @@ impl Game {
     /// Possible teleport destinations that a Heister can reach with a Teleport move
     fn update_possible_teleports(&mut self, grid: &HashMap<MapPosition, Square>) -> () {
         let mut m: HashMap<HeisterColor, Vec<MapPosition>> = HashMap::new();
-        if !self.game_state.all_items_taken {
-            // if teleports are still allowed
-            for heister in &self.game_state.heisters {
-                let color = heister.heister_color;
-                let pos = &heister.map_position;
-                let square = grid.get(&pos).unwrap();
-                if !self.game_options.teleport_only_from_portal || square.is_teleport() {
-                    match self.revealed_teleporters.get(&color) {
-                        Some(list) => {
-                            m.insert(color, list.to_vec());
-                        }
-                        None => {}
+        for heister in &self.game_state.heisters {
+            let color = heister.heister_color;
+            let pos = &heister.map_position;
+            let square = grid.get(&pos).unwrap();
+            if !self.game_options.teleport_only_from_portal || square.is_teleport() {
+                match self.revealed_teleporters.get(&color) {
+                    Some(list) => {
+                        m.insert(color, list.to_vec());
                     }
+                    None => {}
                 }
             }
         }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -427,6 +427,22 @@ impl GameState {
         }
     }
 
+    /// This will check for each heister and update its "has_taken_item" field
+    /// This will also update the game state field "all_items_taken"
+    pub fn update_items_taken(&mut self, grid: &HashMap<MapPosition, Square>) -> () {
+        for heister in &mut self.heisters {
+            match grid.get(&heister.map_position) {
+                Some(square) => {
+                    heister.has_taken_item = self.all_items_taken
+                        || square.is_item() && square.color().unwrap() == heister.heister_color;
+                }
+                None => {}
+            }
+        }
+        self.all_items_taken =
+            self.all_items_taken || self.heisters.iter().all(|h| h.has_taken_item);
+    }
+
     /// in order to update the door to be a clear wall, we need a few things:
     /// 1. we need a reference to the tile in self.tiles that contains the heister_square
     /// 2. we need to be able to know which wall on which square  to update

--- a/src/types.rs
+++ b/src/types.rs
@@ -556,7 +556,21 @@ impl Square {
             SquareType::OrangeTeleportPad => Some(HeisterColor::Orange),
             SquareType::GreenTeleportPad => Some(HeisterColor::Green),
             SquareType::YellowTeleportPad => Some(HeisterColor::Yellow),
+            SquareType::PurpleItem => Some(HeisterColor::Purple),
+            SquareType::OrangeItem => Some(HeisterColor::Orange),
+            SquareType::GreenItem => Some(HeisterColor::Green),
+            SquareType::YellowItem => Some(HeisterColor::Yellow),
             _wildcard => None,
+        }
+    }
+
+    pub fn is_item(&self) -> bool {
+        match self.square_type {
+            SquareType::PurpleItem
+            | SquareType::YellowItem
+            | SquareType::OrangeItem
+            | SquareType::GreenItem => true,
+            _wildcard => false,
         }
     }
 


### PR DESCRIPTION
Logic to update all_items_taken, and also has_taken_item per heister.

Also... does the changes for teleports to prevent keyboard teleports. Actually, tbh, I'm going to take that change out. I think it should just send a failing teleport then. I think it's OK if it does that.

fix #142 