### PR TITLE
Add tap buttons besides player names

### DIFF
--- a/ui/src/components/main.css
+++ b/ui/src/components/main.css
@@ -87,8 +87,14 @@ button {
   padding-bottom: 5px;
 }
 
+/* This means we don't render it at all. */
 .hidden {
   display: none;
+}
+
+/* This means it is still there, just invisible. */
+.invisible {
+  visibility: hidden;
 }
 
 @keyframes pulsate {

--- a/ui/src/components/styles.ts
+++ b/ui/src/components/styles.ts
@@ -24,7 +24,7 @@ const styles: { [key: string]: React.CSSProperties } = {
     bottom: 30,
   },
   connectionStatusOverlay: {
-    zIndex: 5,
+    zIndex: -1,
     position: "relative",
     fontSize: 16,
     textAlign: "center",

--- a/ui/src/join_game/overlay_components.tsx
+++ b/ui/src/join_game/overlay_components.tsx
@@ -1,9 +1,14 @@
+import { getColor, sendChat } from "./api";
+import {
+  heisterSelectedSelector,
+  playerIsSpectatorSelector,
+  playerNameSelector,
+} from "./slice";
+import { useDispatch, useSelector } from "react-redux";
+
 import { Ability } from "../generated/types_pb";
 import { Circle } from "react-konva";
 import React from "react";
-import { getColor } from "./api";
-import { heisterSelectedSelector } from "./slice";
-import { useSelector } from "react-redux";
 
 // The offset makes the center of the image be the center of the canvas element.
 type ResetMapComponentProps = {
@@ -52,6 +57,42 @@ export const ActiveHeisterKeyboardComponent = ({
   );
 };
 
+type TapButtonComponentProps = {
+  name_prefix: string;
+};
+export const TapButtonComponent = ({
+  name_prefix,
+}: TapButtonComponentProps) => {
+  const dispatch = useDispatch();
+  const player_name = useSelector(playerNameSelector);
+
+  const onClick = (_event) => {
+    let recipient = name_prefix.split("'").slice(0, -1).join("'");
+    let msg = `${player_name}: tap ${recipient}`;
+    dispatch(sendChat(msg)); // todo
+  };
+
+  const is_self = name_prefix === "Your";
+  const pointer_events = is_self ? "none" : "auto";
+  const text = is_self ? "-" : "Tap";
+  const class_name = is_self ? "invisible" : undefined;
+
+  return (
+    <button
+      className={class_name}
+      style={{
+        borderRadius: 6,
+        fontSize: 16,
+        pointerEvents: pointer_events,
+        width: 50,
+      }}
+      onClick={onClick}
+    >
+      {text}
+    </button>
+  );
+};
+
 type PlayerAbilitiesProps = {
   name_prefix: string;
   proto_abilities: number[];
@@ -60,6 +101,8 @@ export const PlayerAbilities = ({
   name_prefix,
   proto_abilities,
 }: PlayerAbilitiesProps) => {
+  const player_is_spectator = useSelector(playerIsSpectatorSelector);
+
   const getAbilityEmoji = (proto_ability): string => {
     switch (proto_ability) {
       case Ability.MOVE_NORTH:
@@ -90,10 +133,12 @@ export const PlayerAbilities = ({
     );
   }
 
-  console.log("FINDFLSKDF", abilities_string);
-
   return (
     <p>
+      {player_is_spectator ? null : (
+        <TapButtonComponent name_prefix={name_prefix} />
+      )}
+      &nbsp;&nbsp;
       {name_prefix} abilities: {abilities_string}
     </p>
   );

--- a/ui/src/join_game/slice.ts
+++ b/ui/src/join_game/slice.ts
@@ -16,7 +16,6 @@ import {
 
 import { ConnectionStatus } from "./types";
 import { RootState } from "../common/reducers";
-import { stat } from "fs";
 
 const WEBSOCKET_BROKEN_FULL = WEBSOCKET_ACTION_PREFIX_FULL.concat(
   WEBSOCKET_BROKEN
@@ -200,7 +199,7 @@ const joinGameSlice = createSlice({
     [WEBSOCKET_SEND_FULL]: (_state, _action) => {
       console.debug("Sending message over websocket");
     },
-    [WEBSOCKET_ERROR_FULL]: (state, action) => {
+    [WEBSOCKET_ERROR_FULL]: (state, _action) => {
       let msg = `Failed to join. Is the game handle valid?`;
       pushToPlayerMessageQueue(state.player_message_queue, msg);
     },


### PR DESCRIPTION
Addresses the last part of https://github.com/banool/team_heist_tactics/issues/147.

Looks like this. I tried having a non-clickable button beside your own abilities instead but it still looks like something you should be able to click on.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/7816187/87844765-75204780-c875-11ea-9e9b-21722868bbf4.png">

You can see the jank with which I implemented the taps. Ultimately it goes alright I reckon. I should probably move the prefix logic deeper in to the abilities component, or a flag saying whether it is the self player or not, so I don't have to check against `Your`.