### PR TITLE
Prevent Victory <-> Defeat transitions & ensure client gets latest Status

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -253,8 +253,12 @@ impl Game {
         }
     }
 
-    fn pre_update_auxilliary_state(&mut self) {
+    fn update_game_status(&mut self) {
         self.game_state.update_game_status();
+    }
+
+    fn pre_update_auxilliary_state(&mut self) {
+        self.update_game_status();
     }
 
     fn update_auxiliary_state(&mut self) -> () {
@@ -263,6 +267,7 @@ impl Game {
         self.game_state.update_possible_placements(&grid);
         self.game_state.update_possible_escalators(&grid);
         self.update_possible_teleports(&grid);
+        self.update_game_status();
     }
 
     /// Possible teleport destinations that a Heister can reach with a Teleport move

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -436,17 +436,19 @@ impl GameState {
     }
 
     /// This will check for victory/defeat conditions as part of update_auxiliary_state.
-    /// (intended to capure state changes due to timer)
+    /// (intended to capture state changes due to timer)
     pub fn update_game_status(&mut self) -> () {
-        if self.all_items_taken && self.heisters.iter().all(|h| h.has_escaped) {
-            self.game_status = GameStatus::Victory;
-            return;
-        }
-        let now = get_current_time_secs();
-        if self.game_started != 0 && now > self.timer_runs_out {
-            info!("Time ran out for game {:?}, you lost!", self.game_name);
-            self.game_status = GameStatus::Defeat;
-            return;
+        if self.game_status == GameStatus::Ongoing {
+            if self.all_items_taken && self.heisters.iter().all(|h| h.has_escaped) {
+                self.game_status = GameStatus::Victory;
+                return;
+            }
+            let now = get_current_time_secs();
+            if self.game_started != 0 && now > self.timer_runs_out {
+                info!("Time ran out for game {:?}, you lost!", self.game_name);
+                self.game_status = GameStatus::Defeat;
+                return;
+            }
         }
     }
 

--- a/ui/src/join_game/TimerComponent.tsx
+++ b/ui/src/join_game/TimerComponent.tsx
@@ -28,13 +28,6 @@ const TimerComponent = () => {
   };
 
   const getMessage = (): string => {
-    let defeat_message = "Defeat! You ran out of time!";
-    // We do this check because when the game enters a terminal state,
-    // it isn't guaranteed that the server will push this state to
-    // the client right now.
-    if (seconds_left < 0) {
-      return defeat_message;
-    }
     switch (+game_status) {
       case GameStatus.STAGING:
         throw "Shouldn't see this component while STAGING";
@@ -43,9 +36,11 @@ const TimerComponent = () => {
       case GameStatus.ONGOING:
         return `Seconds left: ${seconds_left}`;
       case GameStatus.VICTORY:
-        return "Victory! You made it out with ${seconds_left} to spare, congrats!";
+        // TODO: we should include ${seconds_left} here - however, the timer
+        // continues to update after the game is in Victory state
+        return "Victory!";
       case GameStatus.DEFEAT:
-        return defeat_message;
+        return "Defeat! You ran out of time!";
     }
     throw "Should not be able to get here";
   };


### PR DESCRIPTION
This was one that was bothering me.

Looks like pretty much I only had to do 2 things... ok 3

1. ensure `update_game_status()` gets called not only at start of `process_move()` but also at the end
2. add a check in `update_game_status()` that ensures you only transition to `Victory||Defeat` from the `Ongoing` state.
3. remove mention of `seconds_left` from the victory message, since making it not count to negative (or even stop counting) is fishy. I was trying out getting it to just stop counting down, but the problem there is that if the client hasn't actually updated the timer in like N seconds (N > 10, at least, usually) - then the resulting "high score" time printed will be inaccurate (and maybe different for different players? idk)

close #209 